### PR TITLE
update for the 2.10 dev sdk

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,33 +1,33 @@
 language: dart
 dart:
-  - dev
+  - preview/raw/2.10.0-0.2-dev
 
 jobs:
   include:
     - stage: analyze_and_format
       name: "Analyze lib/"
-      dart: dev
+      dart: preview/raw/2.10.0-0.2-dev
       os: linux
       script: dartanalyzer --fatal-warnings --fatal-infos lib/
     # Dirs outside of `lib` are not supported by allowed_experiments.json
     - stage: analyze_and_format
       name: "Analyze test/"
-      dart: dev
+      dart: preview/raw/2.10.0-0.2-dev
       os: linux
       script: dartanalyzer --enable-experiment=non-nullable --fatal-warnings --fatal-infos test/
     - stage: analyze_and_format
       name: "Format"
-      dart: dev
+      dart: preview/raw/2.10.0-0.2-dev
       os: linux
       script: dartfmt -n --set-exit-if-changed .
     - stage: test
       name: "Vm Tests"
-      dart: dev
+      dart: preview/raw/2.10.0-0.2-dev
       os: linux
       script: pub run --enable-experiment=non-nullable test -p vm 
     - stage: test
       name: "Web Tests"
-      dart: dev
+      dart: preview/raw/2.10.0-0.2-dev
       os: linux
       script: pub run --enable-experiment=non-nullable test -p chrome
 
@@ -37,7 +37,7 @@ stages:
 
 # Only building master means that we don't run two builds for each pull request.
 branches:
-  only: [master, null_safety]
+  only: [master]
 
 cache:
  directories:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.3.0-nullsafety.2
+
+* Update for the 2.10 dev sdk.
+
 ## 1.3.0-nullsafety.1
 
 * Allow the <=2.9.10 stable sdks.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,8 +5,8 @@ description: >-
   Utility functions and classes related to the dart:typed_data library.
 homepage: https://github.com/dart-lang/typed_data
 
-environment:
-  sdk: '>=2.9.0-18.0 <=2.9.10'
+  # This must remain a tight constraint until nnbd is stable
+  sdk: '>=2.10.0-0 <2.10.0'
 
 dependencies:
   collection: '>=1.15.0-nullsafety <1.15.0'
@@ -22,16 +22,20 @@ dependency_overrides:
     git: git://github.com/dart-lang/boolean_selector.git
   charcode:
     git: git://github.com/dart-lang/charcode.git
+  collection:
+    git: git://github.com/dart-lang/collection.git
   js:
     git:
       url: git://github.com/dart-lang/sdk.git
       path: pkg/js
+      ref: 2-10-pkgs
   matcher:
     git: git://github.com/dart-lang/matcher.git
   meta:
     git:
       url: git://github.com/dart-lang/sdk.git
       path: pkg/meta
+      ref: 2-10-pkgs
   path:
     git: git://github.com/dart-lang/path.git
   pedantic:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,6 +5,7 @@ description: >-
   Utility functions and classes related to the dart:typed_data library.
 homepage: https://github.com/dart-lang/typed_data
 
+environment:
   # This must remain a tight constraint until nnbd is stable
   sdk: '>=2.10.0-0 <2.10.0'
 


### PR DESCRIPTION
This is in preparation for the actual 2.10 dev sdk release. This package needs to be published and pinned in flutter simultaneously with that release.

The tests are going to be failing until we update all transitive deps in a similar fashion (they need to declare a 2.10 language version).

The plan for lack of a better option is to just do these all as quickly as possible (and merge them into master), and then go re-run the travis jobs to get the build green again afterwords.