### PR TITLE
Prepare for the 2.11 dev SDKs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.3.0-nullsafety.3
+
+* Allow 2.10 stable and 2.11.0 dev SDK versions.
+
 ## 1.3.0-nullsafety.2
 
 * Update for the 2.10 dev sdk.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: typed_data
-version: 1.3.0-nullsafety.2
+version: 1.3.0-nullsafety.3
 
 description: >-
   Utility functions and classes related to the dart:typed_data library.
@@ -7,7 +7,7 @@ homepage: https://github.com/dart-lang/typed_data
 
 environment:
   # This must remain a tight constraint until nnbd is stable
-  sdk: '>=2.10.0-0 <2.10.0'
+  sdk: '>=2.10.0-0 <2.11.0'
 
 dependencies:
   collection: '>=1.15.0-nullsafety <1.15.0'


### PR DESCRIPTION
Bump the upper bound to allow 2.10 stable and 2.11.0 dev SDK versions.