### PR TITLE
Bump SDK constraints for pub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.3.0-nullsafety.5
+
+* Update SDK constraints to `>=2.12.0-0 <3.0.0` based on beta release
+  guidelines.
+
 ## 1.3.0-nullsafety.4
 
 * Allow prerelease versions of the `2.12` sdk.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,13 +1,12 @@
 name: typed_data
-version: 1.3.0-nullsafety.4
+version: 1.3.0-nullsafety.5
 
 description: >-
   Utility functions and classes related to the dart:typed_data library.
 homepage: https://github.com/dart-lang/typed_data
 
 environment:
-  # This must remain a tight constraint until nnbd is stable
-  sdk: '>=2.10.0-0 <2.12.0'
+  sdk: ">=2.12.0-0 <3.0.0"
 
 dependencies:
   collection: '>=1.15.0-nullsafety <1.15.0'


### PR DESCRIPTION
Use a 2.12.0 lower bound since pub does not understand allowed
experiments for earlier versions.

Use a 3.0.0 upper bound to avoid a warning in pub and to give some
flexibility in publishing for stable.