### PR TITLE
Update to `package:dart_flutter_team_lints` version ^2.1.0

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,18 +1,16 @@
-# https://dart.dev/guides/language/analysis-options
+# https://dart.dev/tools/analysis
 include: package:dart_flutter_team_lints/analysis_options.yaml
 
 analyzer:
   language:
     strict-casts: true
+    strict-inference: true
+    strict-raw-types: true
 
 linter:
   rules:
     - avoid_returning_null
     - avoid_unused_constructor_parameters
     - cancel_subscriptions
-    - comment_references
     - no_adjacent_strings_in_list
     - package_api_docs
-    - prefer_const_constructors
-    - test_types_in_equals
-    - use_super_parameters

--- a/lib/src/typed_buffer.dart
+++ b/lib/src/typed_buffer.dart
@@ -159,7 +159,7 @@ abstract class TypedDataBuffer<E> extends ListBase<E> {
   }
 
   // Reverses the range [start..end) of buffer.
-  static void _reverse(List buffer, int start, int end) {
+  void _reverse(List<E> buffer, int start, int end) {
     end--; // Point to last element, not after last element.
     while (start < end) {
       var first = buffer[start];

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,5 +14,5 @@ dependencies:
   collection: ^1.15.0
 
 dev_dependencies:
-  dart_flutter_team_lints: ^1.0.0
+  dart_flutter_team_lints: ^2.1.0
   test: ^1.16.0

--- a/test/typed_buffers_test.dart
+++ b/test/typed_buffers_test.dart
@@ -558,7 +558,7 @@ class MatchesInt32x4 extends Matcher {
       description.add('Int32x4.==');
 
   @override
-  bool matches(Object? item, Map matchState) =>
+  bool matches(Object? item, Map<dynamic, dynamic> matchState) =>
       item is Int32x4 &&
       result.x == item.x &&
       result.y == item.y &&


### PR DESCRIPTION
- Updates to `package:dart_flutter_team_lints` version ^2.1.0
  - Then removes now duplicated linter rules.
 - Also enables `strict-raw-types` analyzer language mode and fixes the instances of it.