### PR TITLE
Allow upcoming package:collection version 2.x

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
   sdk: ^3.0.0
 
 dependencies:
-  collection: ^1.15.0
+  collection: '>=1.15.0 <3.0.0'
 
 dev_dependencies:
   dart_flutter_team_lints: ^2.0.0


### PR DESCRIPTION
There will not be a breaking change in package:collection that concerns this package, but currently due to a circular dependency it's not even possible to bump said package's version to 2.0.

* See the CI failure in https://github.com/dart-lang/collection/pull/331

```console
$ dart pub get
Resolving dependencies...
Because test >=1.16.0 depends on typed_data ^1.3.0 which depends on collection ^1.15.0, test >=1.16.0 requires collection ^1.15.0.
So, because collection depends on test ^1.16.0 and collection is 2.0.0-wip, version solving failed.
```

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
