### PR TITLE
Require Dart 3.5, use TypeDataList in many places

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -47,7 +47,7 @@ jobs:
       matrix:
         # Add macos-latest and/or windows-latest if relevant for this package.
         os: [ubuntu-latest]
-        sdk: [3.1, dev]
+        sdk: [3.5, dev]
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
       - uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
@@ -64,5 +64,4 @@ jobs:
         if: always() && steps.install.outcome == 'success'
       - name: Run Chrome tests - wasm
         run: dart test --platform chrome --compiler dart2wasm
-        # TODO: drop `dev` filter when dart2wasm is working on stable
-        if: always() && steps.install.outcome == 'success' && matrix.sdk == 'dev'
+        if: always() && steps.install.outcome == 'success'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.3.3-wip
+## 1.4.0-wip
 
 * The type of the `buffer` constructor argument to `TypedDataBuffer` is now
   `TypeDataList<E>` (instead of `List<E>`). While this is breaking change

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## 1.3.3-wip
 
-* Require Dart 3.1
+* The type of the `buffer` constructor argument to `TypedDataBuffer` is now
+  `TypeDataList<E>` (instead of `List<E>`). While this is breaking change
+  statically there was a runtime cast that makes this change a no-op in
+  practice. 
+* Require Dart 3.5
 
 ## 1.3.2
 

--- a/lib/src/typed_buffer.dart
+++ b/lib/src/typed_buffer.dart
@@ -9,18 +9,12 @@ abstract class TypedDataBuffer<E> extends ListBase<E> {
   static const int _initialLength = 8;
 
   /// The underlying data buffer.
-  ///
-  /// This is always both a List<E> and a TypedData, which we don't have a type
-  /// for here. For example, for a `Uint8Buffer`, this is a `Uint8List`.
-  List<E> _buffer;
-
-  /// Returns a view of [_buffer] as a [TypedData].
-  TypedData get _typedBuffer => _buffer as TypedData;
+  TypedDataList<E> _buffer;
 
   /// The length of the list being built.
   int _length;
 
-  TypedDataBuffer(List<E> buffer)
+  TypedDataBuffer(TypedDataList<E> buffer)
       : _buffer = buffer,
         _length = buffer.length;
 
@@ -47,7 +41,7 @@ abstract class TypedDataBuffer<E> extends ListBase<E> {
         _buffer[i] = defaultValue;
       }
     } else if (newLength > _buffer.length) {
-      List<E> newBuffer;
+      TypedDataList<E> newBuffer;
       if (_buffer.isEmpty) {
         newBuffer = _createBuffer(newLength);
       } else {
@@ -249,7 +243,7 @@ abstract class TypedDataBuffer<E> extends ListBase<E> {
   /// be. If [requiredCapacity] is not null, it will be at least that
   /// size. It will always have at least have double the capacity of
   /// the current buffer.
-  List<E> _createBiggerBuffer(int? requiredCapacity) {
+  TypedDataList<E> _createBiggerBuffer(int? requiredCapacity) {
     var newLength = _buffer.length * 2;
     if (requiredCapacity != null && newLength < requiredCapacity) {
       newLength = requiredCapacity;
@@ -283,11 +277,11 @@ abstract class TypedDataBuffer<E> extends ListBase<E> {
 
   // TypedData.
 
-  int get elementSizeInBytes => _typedBuffer.elementSizeInBytes;
+  int get elementSizeInBytes => _buffer.elementSizeInBytes;
 
-  int get lengthInBytes => _length * _typedBuffer.elementSizeInBytes;
+  int get lengthInBytes => _length * _buffer.elementSizeInBytes;
 
-  int get offsetInBytes => _typedBuffer.offsetInBytes;
+  int get offsetInBytes => _buffer.offsetInBytes;
 
   /// Returns the underlying [ByteBuffer].
   ///
@@ -295,7 +289,7 @@ abstract class TypedDataBuffer<E> extends ListBase<E> {
   /// of this list.
   ///
   /// The buffer may be larger than [lengthInBytes] bytes, but never smaller.
-  ByteBuffer get buffer => _typedBuffer.buffer;
+  ByteBuffer get buffer => _buffer.buffer;
 
   // Specialization for the specific type.
 
@@ -304,7 +298,7 @@ abstract class TypedDataBuffer<E> extends ListBase<E> {
   E get _defaultValue;
 
   // Create a new typed list to use as buffer.
-  List<E> _createBuffer(int size);
+  TypedDataList<E> _createBuffer(int size);
 }
 
 abstract class _IntBuffer extends TypedDataBuffer<int> {

--- a/lib/src/typed_queue.dart
+++ b/lib/src/typed_queue.dart
@@ -10,20 +10,16 @@ import 'package:collection/collection.dart';
 import 'typed_buffer.dart';
 
 /// The shared superclass of all the typed queue subclasses.
-abstract class _TypedQueue<E, L extends List<E>> with ListMixin<E> {
+abstract class _TypedQueue<E, L extends TypedDataList<E>> with ListMixin<E> {
   /// The underlying data buffer.
-  ///
-  /// This is always both a List<E> and a TypedData, which we don't have a type
-  /// for that. For example, for a `Uint8Queue`, this is a `Uint8List`.
-  L _table;
+  TypedDataList<E> _table;
 
   int _head;
   int _tail;
 
   /// Create an empty queue.
-  _TypedQueue(List<E> table)
-      : _table = table as L,
-        _head = 0,
+  _TypedQueue(this._table)
+      : _head = 0,
         _tail = 0;
 
   // Iterable interface.
@@ -330,20 +326,21 @@ abstract class _TypedQueue<E, L extends List<E>> with ListMixin<E> {
   L _createList(int size);
 
   // Create a new typed buffer of the given type.
-  List<E> _createBuffer(int size);
+  TypedDataBuffer<E> _createBuffer(int size);
 
   /// The default value used to fill the queue when changing length.
   E get _defaultValue;
 }
 
-abstract class _IntQueue<L extends List<int>> extends _TypedQueue<int, L> {
+abstract class _IntQueue<L extends TypedDataList<int>>
+    extends _TypedQueue<int, L> {
   _IntQueue(super.queue);
 
   @override
   int get _defaultValue => 0;
 }
 
-abstract class _FloatQueue<L extends List<double>>
+abstract class _FloatQueue<L extends TypedDataList<double>>
     extends _TypedQueue<double, L> {
   _FloatQueue(super.queue);
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ topics:
   - data-structures
 
 environment:
-  sdk: ^3.1.0
+  sdk: ^3.5.0
 
 dependencies:
   collection: ^1.15.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: typed_data
-version: 1.3.3-wip
+version: 1.4.0-wip
 description: >-
   Utility functions and classes related to the dart:typed_data library.
 repository: https://github.com/dart-lang/typed_data


### PR DESCRIPTION
Tighten types, remove casts, etc
